### PR TITLE
Make _curry function static

### DIFF
--- a/src/pramda.php
+++ b/src/pramda.php
@@ -2403,7 +2403,7 @@ class P
      *
      * @return callable
      */
-    private function _curry(callable $callable, $args, $arity)
+    private static function _curry(callable $callable, $args, $arity)
     {
 
         return function () use ($callable, $args, $arity) {


### PR DESCRIPTION
It fixes the following warning mentioned in #9 issue:

Deprecated: Non-static method P::_curry() should not be called statically
