### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Pramda uses the venerable PHPUnit for testing.
 
 ```bash
 
-#vendor\bin\phpunit.bat --debug
+# vendor\bin\phpunit.bat --debug
 PHPUnit 4.8.21 by Sebastian Bergmann and contributors.
 
 ................................................................ 64 / 79 ( 81%)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
