### PR TITLE
Support PHPUnit 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4"
+        "phpunit/phpunit": "~4.8.36 || ~5.7"
     },
     "autoload": {
         "classmap": [

--- a/tests/pramda.php
+++ b/tests/pramda.php
@@ -1,6 +1,8 @@
 <?php
 
-class Pramda_TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Pramda_TestCase extends TestCase
 {
 
     public function testAdd()
@@ -1090,4 +1092,3 @@ class Pramda_TestCase extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['1a', '2b'], $concat([1, 2], $a()));
     }
 }
- 


### PR DESCRIPTION
I've added PHPUnit 5 support. Also, I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump `PHPUnit 4` to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.